### PR TITLE
[DNM] remove repository definition for Apache

### DIFF
--- a/cookbooks/ceph-qa/recipes/centos6.rb
+++ b/cookbooks/ceph-qa/recipes/centos6.rb
@@ -31,19 +31,12 @@ priority=2
   EOH
 end
 
-
+# We no longer need a custom version of Apache.
 file '/etc/yum.repos.d/apache-ceph.repo' do
   owner 'root'
   group 'root'
   mode '0644'
-  content <<-EOH
-[centos6-apache-ceph]
-name=Cent OS 6 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-centos6-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  content ''
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -211,33 +204,8 @@ package 'genisoimage'
 
 #Rados GW
 
-#Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
-  action :remove
-end
-package 'http-devel' do
-  action :remove
-end
-package 'httpd-tools' do
-  action :remove
-end
-package 'mod_ssl' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-tools' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-devel' do
-  version '2.2.22-1.ceph.el6'
-end
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el6'
-end
-service "httpd" do
-  action [ :disable, :stop ]
 end
 package 'python-pip'
 package 'python-devel'

--- a/cookbooks/ceph-qa/recipes/centos7.rb
+++ b/cookbooks/ceph-qa/recipes/centos7.rb
@@ -9,18 +9,12 @@ cookbook_file '/etc/yum.repos.d/epel.repo' do
   group "root"
 end
 
+# We no longer need a custom version of Apache.
 file '/etc/yum.repos.d/apache-ceph.repo' do
   owner 'root'
   group 'root'
   mode '0644'
-  content <<-EOH
-[centos7-apache-ceph]
-name=CentOS 7 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-centos7-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  content ''
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -111,34 +105,8 @@ package 'qemu-guest-agent'
 package 'genisoimage'
 
 #Rados GW
-
-#Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
-  action :remove
-end
-package 'http-devel' do
-  action :remove
-end
-package 'httpd-tools' do
-  action :remove
-end
-package 'mod_ssl' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd-tools' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd-devel' do
-  version '2.4.6-17_ceph.el7'
-end
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el7'
-end
-service "httpd" do
-  action [ :disable, :stop ]
 end
 
 package 'python-pip'

--- a/cookbooks/ceph-qa/recipes/debian.rb
+++ b/cookbooks/ceph-qa/recipes/debian.rb
@@ -75,13 +75,11 @@ file '/etc/apt/sources.list.d/radosgw.list' do
   if node[:platform_version] >= "7.0" and node[:platform_version] < "8.0"
     # pull from wheezy gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-wheezy-x86_64-basic/ref/master/ wheezy main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-wheezy-x86_64-basic/ref/master/ wheezy main
 EOH
   elsif node[:platform_version] >= "6.0" and node[:platform_version] < "7.0"
     # pull from squeeze gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-squeeze-x86_64-basic/ref/master/ squeeze main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-squeeze-x86_64-basic/ref/master/ squeeze main
 EOH
   else
@@ -135,17 +133,10 @@ if node[:platform_version] >= "6.0" and node[:platform_version] < "7.0"
 end
 
 #RADOS GW
-package 'apache2' do
-  action :upgrade
-end
 package 'libapache2-mod-fastcgi' do
   action :upgrade
 end
 package 'libfcgi0ldbl'
-
-service "apache2" do
-  action [ :disable, :stop ]
-end
 
 
 # for running ceph

--- a/cookbooks/ceph-qa/recipes/fedora.rb
+++ b/cookbooks/ceph-qa/recipes/fedora.rb
@@ -21,20 +21,12 @@ cookbook_file '/etc/default/grub' do
   group "root"
 end
 
-
-
+# We no longer need a custom version of Apache.
 file '/etc/yum.repos.d/apache-ceph.repo' do
   owner 'root'
   group 'root'
   mode '0644'
-  content <<-EOH
-[fedora-apache-ceph]
-name=Fedora Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-fedora#{node.platform_version}-x86_64-basic/ref/master/
-priority=0
-pgcheck=0
-enabled=1
-  EOH
+  content ''
 end
   
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -149,75 +141,23 @@ end
 
 #Rados GW
 
-#Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
-  action :remove
-end
-package 'http-devel' do
-  action :remove
-end
-package 'httpd-tools' do
-  action :remove
-end
-
 if node[:platform_version] == "18"
-  package 'mod_ssl' do
-    version '2.2.22-1.ceph.fc18'
-  end
-  package 'httpd' do
-    version '2.2.22-1.ceph.fc18'
-  end
-  package 'httpd-tools' do
-    version '2.2.22-1.ceph.fc18'
-  end
-  package 'httpd-devel' do
-    version '2.2.22-1.ceph.fc18'
-  end
   package 'mod_fastcgi' do
     version '2.4.7-1.ceph.fc18'
   end
 end
 
 if node[:platform_version] == "19"
-  package 'mod_ssl' do
-    version '2.2.22-1.ceph.fc19'
-  end
-  package 'httpd' do
-    version '2.2.22-1.ceph.fc19'
-  end
-  package 'httpd-tools' do
-    version '2.2.22-1.ceph.fc19'
-  end
-  package 'httpd-devel' do
-    version '2.2.22-1.ceph.fc19'
-  end
   package 'mod_fastcgi' do
     version '2.4.7-1.ceph.fc19'
   end
 end
 
 if node[:platform_version] == "20"
-  package 'mod_ssl' do
-    version '2.4.6-17_ceph.fc20'
-  end
-  package 'httpd' do
-    version '2.4.6-17_ceph.fc20'
-  end
-  package 'httpd-tools' do
-    version '2.4.6-17_ceph.fc20'
-  end
-  package 'httpd-devel' do
-    version '2.4.6-17_ceph.fc20'
-  end
   package 'mod_fastcgi' do
     version '2.4.7-1.ceph.fc20'
   end
 end
-
-service "httpd" do
-  action [ :disable, :stop ]
-end
-
 
 # for qemu:
 package 'genisoimage'

--- a/cookbooks/ceph-qa/recipes/radosgw.rb
+++ b/cookbooks/ceph-qa/recipes/radosgw.rb
@@ -22,26 +22,22 @@ file '/etc/apt/sources.list.d/radosgw.list' do
     # pull from precise gitbuilder
     content <<-EOH
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-precise-x86_64-basic/ref/master/ precise main
-deb http://gitbuilder.ceph.com/apache2-deb-precise-x86_64-basic/ref/master/ precise main
 EOH
   elsif node[:platform_version] == "11.10"
     # pull from oneiric gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-oneiric-x86_64-basic/ref/master/ oneiric main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-oneiric-x86_64-basic/ref/master/ oneiric main
 EOH
   elsif node[:platform_version] == "12.10"
     if node[:languages][:ruby][:host_cpu] == "arm"
       # pull from arm repo
       content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-quantal-armv7l-basic/ref/master/ quantal main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-quantal-armv7l-basic/ref/master/ quantal main
 EOH
     end
   elsif node[:platform_version] == "14.04"
     # pull from oneiric gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-trusty-x86_64-basic/ref/master/ trusty main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-trusty-x86_64-basic/ref/master/ trusty main
 EOH
   else
@@ -55,14 +51,7 @@ execute 'apt-get update' do
   command 'apt-get update'
 end
 
-package 'apache2' do
-  action :upgrade
-end
 package 'libapache2-mod-fastcgi' do
   action :upgrade
 end
 package 'libfcgi0ldbl'
-
-service "apache2" do
-  action [ :disable, :stop ]
-end

--- a/cookbooks/ceph-qa/recipes/redhat6.rb
+++ b/cookbooks/ceph-qa/recipes/redhat6.rb
@@ -61,19 +61,12 @@ priority=2
   EOH
 end
 
-
+# We no longer need a custom version of Apache.
 file '/etc/yum.repos.d/apache-ceph.repo' do
   owner 'root'
   group 'root'
   mode '0644'
-  content <<-EOH
-[centos6-apache-ceph]
-name=Cent OS 6 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-rhel6-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  content ''
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -227,35 +220,9 @@ package 'genisoimage'
 
 #Rados GW
 
-#Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
-  action :remove
-end
-package 'http-devel' do
-  action :remove
-end
-package 'httpd-tools' do
-  action :remove
-end
-package 'mod_ssl' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-tools' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-devel' do
-  version '2.2.22-1.ceph.el6'
-end
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el6'
 end
-service "httpd" do
-  action [ :disable, :stop ]
-end
-
 
 package 'python-pip'
 package 'libevent-devel'

--- a/cookbooks/ceph-qa/recipes/redhat7.rb
+++ b/cookbooks/ceph-qa/recipes/redhat7.rb
@@ -49,18 +49,12 @@ enabled=1
   EOH
 end
 
+# We no longer need a custom version of Apache.
 file '/etc/yum.repos.d/apache-ceph.repo' do
   owner 'root'
   group 'root'
   mode '0644'
-  content <<-EOH
-[rhel7-apache-ceph]
-name=RHEL 7 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-rhel7-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  content ''
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -192,36 +186,9 @@ package 'genisoimage'
 
 #Rados GW
 
-#Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
-  action :remove
-end
-package 'http-devel' do
-  action :remove
-end
-package 'httpd-tools' do
-  action :remove
-end
-package 'mod_ssl' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd-tools' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd-devel' do
-  version '2.4.6-17_ceph.el7'
-end
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el7'
 end
-service "httpd" do
-  action [ :disable, :stop ]
-end
-
-
 
 package 'python-pip'
 package 'libevent-devel'


### PR DESCRIPTION
It's better to rely on the distro Apache packages. See thread on ceph-devel, "Ceph's custom apache: ok to drop?" http://comments.gmane.org/gmane.comp.file-systems.ceph.devel/22368
