### PR TITLE
Enabled logging of statistics in NTP for NTP testing.

### DIFF
--- a/cookbooks/ceph-qa/files/default/ntp.conf
+++ b/cookbooks/ceph-qa/files/default/ntp.conf
@@ -4,12 +4,14 @@ driftfile /var/lib/ntp/ntp.drift
 
 
 # Enable this if you want statistics to be logged.
-#statsdir /var/log/ntpstats/
+statsdir /var/log/ntpstats/
 
-statistics loopstats peerstats clockstats
+statistics loopstats peerstats rawstats clockstats sysstats
 filegen loopstats file loopstats type day enable
 filegen peerstats file peerstats type day enable
+filegen rawstats file rawstats type day enable
 filegen clockstats file clockstats type day enable
+filegen sysstats file sysstats type day enable
 
 
 # You do need to talk to an NTP server or two (or three).


### PR DESCRIPTION
Turned on logging of loopstats, peerstats, rawstats, clockstats, and sysstats in ntp.conf.
The statistics will be needed to test and monitor NTP for analysis of time synchronization.
