### PR TITLE
ntp.conf: switch ntp server to tock.phyber.com

### DIFF
--- a/cookbooks/ceph-qa/files/default/ntp.conf
+++ b/cookbooks/ceph-qa/files/default/ntp.conf
@@ -23,9 +23,13 @@ filegen sysstats file sysstats type day enable
 
 #clock1 is currently an alias to public ntp servers, which are 20-50ms off from
 #our internal ones!
+
+# found this guy from http://www.pool.ntp.org/user/ask, ~2.5ms ping time
+server tock.phyber.com iburst minpoll 4 maxpoll 7
+
 #server clock1.dreamhost.com iburst dynamic
 #server clock2.dreamhost.com iburst dynamic
-server clock3.dreamhost.com iburst minpoll 4 maxpoll 7
+#server clock3.dreamhost.com iburst minpoll 4 maxpoll 7
 #server 0.debian.pool.ntp.org iburst dynamic
 #server 1.debian.pool.ntp.org iburst dynamic
 #server 2.debian.pool.ntp.org iburst dynamic


### PR DESCRIPTION
clock3 is down.

Signed-off-by: Sage Weil <sage@redhat.com>