### PR TITLE
Use the distro provided apache, not our forked version

### DIFF
--- a/cookbooks/ceph-qa/recipes/centos6.rb
+++ b/cookbooks/ceph-qa/recipes/centos6.rb
@@ -32,18 +32,9 @@ priority=2
 end
 
 
+# We used to install a forked version of apache, ensure it's repo file doesn't exist
 file '/etc/yum.repos.d/apache-ceph.repo' do
-  owner 'root'
-  group 'root'
-  mode '0644'
-  content <<-EOH
-[centos6-apache-ceph]
-name=Cent OS 6 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-centos6-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  action :delete
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -228,27 +219,19 @@ package 'genisoimage'
 #Rados GW
 
 #Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
+package "httpd" do
   action :remove
 end
-package 'http-devel' do
+package "httpd-devel" do
   action :remove
 end
-package 'httpd-tools' do
+package "httpd-tools" do
   action :remove
 end
-package 'mod_ssl' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-tools' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-devel' do
-  version '2.2.22-1.ceph.el6'
-end
+package 'httpd'
+package 'httpd-devel'
+package 'httpd-tools'
+package 'mod_ssl'
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el6'
 end

--- a/cookbooks/ceph-qa/recipes/centos7.rb
+++ b/cookbooks/ceph-qa/recipes/centos7.rb
@@ -9,18 +9,10 @@ cookbook_file '/etc/yum.repos.d/epel.repo' do
   group "root"
 end
 
+# We used to install a forked version of apache
+# if the repo is still around, delete it
 file '/etc/yum.repos.d/apache-ceph.repo' do
-  owner 'root'
-  group 'root'
-  mode '0644'
-  content <<-EOH
-[centos7-apache-ceph]
-name=CentOS 7 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-centos7-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  action :delete
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -143,27 +135,19 @@ end
 #Rados GW
 
 #Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
+package "httpd" do
   action :remove
 end
-package 'http-devel' do
+package "httpd-devel" do
   action :remove
 end
-package 'httpd-tools' do
+package "httpd-tools" do
   action :remove
 end
-package 'mod_ssl' do
-  version '2.4.6-17_ceph.el7.centos'
-end
-package 'httpd' do
-  version '2.4.6-17_ceph.el7.centos'
-end
-package 'httpd-tools' do
-  version '2.4.6-17_ceph.el7.centos'
-end
-package 'httpd-devel' do
-  version '2.4.6-17_ceph.el7.centos'
-end
+package 'httpd'
+package 'httpd-devel'
+package 'httpd-tools'
+package 'mod_ssl'
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el7.centos'
 end

--- a/cookbooks/ceph-qa/recipes/debian.rb
+++ b/cookbooks/ceph-qa/recipes/debian.rb
@@ -75,13 +75,11 @@ file '/etc/apt/sources.list.d/radosgw.list' do
   if node[:platform_version] >= "7.0" and node[:platform_version] < "8.0"
     # pull from wheezy gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-wheezy-x86_64-basic/ref/master/ wheezy main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-wheezy-x86_64-basic/ref/master/ wheezy main
 EOH
   elsif node[:platform_version] >= "6.0" and node[:platform_version] < "7.0"
     # pull from squeeze gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-squeeze-x86_64-basic/ref/master/ squeeze main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-squeeze-x86_64-basic/ref/master/ squeeze main
 EOH
   else

--- a/cookbooks/ceph-qa/recipes/fedora.rb
+++ b/cookbooks/ceph-qa/recipes/fedora.rb
@@ -22,19 +22,10 @@ cookbook_file '/etc/default/grub' do
 end
 
 
-
+# We used to install a forked version of apache
+# if the repo is still around, delete it
 file '/etc/yum.repos.d/apache-ceph.repo' do
-  owner 'root'
-  group 'root'
-  mode '0644'
-  content <<-EOH
-[fedora-apache-ceph]
-name=Fedora Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-fedora#{node.platform_version}-x86_64-basic/ref/master/
-priority=0
-pgcheck=0
-enabled=1
-  EOH
+  action :delete
 end
   
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -149,65 +140,33 @@ end
 #Rados GW
 
 #Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
+package "httpd" do
   action :remove
 end
-package 'http-devel' do
+package "httpd-devel" do
   action :remove
 end
-package 'httpd-tools' do
+package "httpd-tools" do
   action :remove
 end
+package 'httpd'
+package 'httpd-devel'
+package 'httpd-tools'
+package 'mod_ssl'
 
 if node[:platform_version] == "18"
-  package 'mod_ssl' do
-    version '2.2.22-1.ceph.fc18'
-  end
-  package 'httpd' do
-    version '2.2.22-1.ceph.fc18'
-  end
-  package 'httpd-tools' do
-    version '2.2.22-1.ceph.fc18'
-  end
-  package 'httpd-devel' do
-    version '2.2.22-1.ceph.fc18'
-  end
   package 'mod_fastcgi' do
     version '2.4.7-1.ceph.fc18'
   end
 end
 
 if node[:platform_version] == "19"
-  package 'mod_ssl' do
-    version '2.2.22-1.ceph.fc19'
-  end
-  package 'httpd' do
-    version '2.2.22-1.ceph.fc19'
-  end
-  package 'httpd-tools' do
-    version '2.2.22-1.ceph.fc19'
-  end
-  package 'httpd-devel' do
-    version '2.2.22-1.ceph.fc19'
-  end
   package 'mod_fastcgi' do
     version '2.4.7-1.ceph.fc19'
   end
 end
 
 if node[:platform_version] == "20"
-  package 'mod_ssl' do
-    version '2.4.6-17_ceph.fc20'
-  end
-  package 'httpd' do
-    version '2.4.6-17_ceph.fc20'
-  end
-  package 'httpd-tools' do
-    version '2.4.6-17_ceph.fc20'
-  end
-  package 'httpd-devel' do
-    version '2.4.6-17_ceph.fc20'
-  end
   package 'mod_fastcgi' do
     version '2.4.7-1.ceph.fc20'
   end

--- a/cookbooks/ceph-qa/recipes/radosgw.rb
+++ b/cookbooks/ceph-qa/recipes/radosgw.rb
@@ -32,26 +32,22 @@ file '/etc/apt/sources.list.d/radosgw.list' do
     # pull from precise gitbuilder
     content <<-EOH
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-precise-x86_64-basic/ref/master/ precise main
-deb http://gitbuilder.ceph.com/apache2-deb-precise-x86_64-basic/ref/master/ precise main
 EOH
   elsif node[:platform_version] == "11.10"
     # pull from oneiric gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-oneiric-x86_64-basic/ref/master/ oneiric main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-oneiric-x86_64-basic/ref/master/ oneiric main
 EOH
   elsif node[:platform_version] == "12.10"
     if node[:languages][:ruby][:host_cpu] == "arm"
       # pull from arm repo
       content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-quantal-armv7l-basic/ref/master/ quantal main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-quantal-armv7l-basic/ref/master/ quantal main
 EOH
     end
   elsif node[:platform_version] == "14.04"
     # pull from oneiric gitbuilder
     content <<-EOH
-deb http://gitbuilder.ceph.com/apache2-deb-trusty-x86_64-basic/ref/master/ trusty main
 deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-trusty-x86_64-basic/ref/master/ trusty main
 EOH
   else

--- a/cookbooks/ceph-qa/recipes/redhat6.rb
+++ b/cookbooks/ceph-qa/recipes/redhat6.rb
@@ -77,18 +77,10 @@ priority=2
 end
 
 
+# We used to install a forked version of apache
+# if the repo is still around, delete it
 file '/etc/yum.repos.d/apache-ceph.repo' do
-  owner 'root'
-  group 'root'
-  mode '0644'
-  content <<-EOH
-[centos6-apache-ceph]
-name=Cent OS 6 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-rhel6-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  action :delete
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -243,27 +235,19 @@ package 'genisoimage'
 #Rados GW
 
 #Force downgrade of packages doesnt work on older chef, uninstall first.
-package 'httpd' do
+package "httpd" do
   action :remove
 end
-package 'http-devel' do
+package "httpd-devel" do
   action :remove
 end
-package 'httpd-tools' do
+package "httpd-tools" do
   action :remove
 end
-package 'mod_ssl' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-tools' do
-  version '2.2.22-1.ceph.el6'
-end
-package 'httpd-devel' do
-  version '2.2.22-1.ceph.el6'
-end
+package 'httpd'
+package 'httpd-devel'
+package 'httpd-tools'
+package 'mod_ssl'
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el6'
 end

--- a/cookbooks/ceph-qa/recipes/redhat7.rb
+++ b/cookbooks/ceph-qa/recipes/redhat7.rb
@@ -49,18 +49,10 @@ enabled=1
   EOH
 end
 
+# We used to install a forked version of apache
+# if the repo is still around, delete it
 file '/etc/yum.repos.d/apache-ceph.repo' do
-  owner 'root'
-  group 'root'
-  mode '0644'
-  content <<-EOH
-[rhel7-apache-ceph]
-name=RHEL 7 Local apache Repo
-baseurl=http://gitbuilder.ceph.com/apache2-rpm-rhel7-x86_64-basic/ref/master/
-gpgcheck=0
-enabled=1
-priority=2
-  EOH
+  action :delete
 end
 
 file '/etc/yum.repos.d/fcgi-ceph.repo' do
@@ -225,32 +217,22 @@ end
 package 'httpd' do
   action :remove
 end
-package 'http-devel' do
-  action :remove
-end
-package 'httpd-tools' do
-  action :remove
-end
-package 'mod_ssl' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd' do
-  version '2.4.6-17_ceph.el7'
-end
-package 'httpd-tools' do
-  version '2.4.6-17_ceph.el7'
-end
 package 'httpd-devel' do
-  version '2.4.6-17_ceph.el7'
+  action :remove
 end
+package 'httpd-tools' do
+  action :remove
+end
+package 'httpd'
+package 'httpd-devel'
+package 'httpd-tools'
+package 'mod_ssl'
 package 'mod_fastcgi' do
   version '2.4.7-1.ceph.el7'
 end
 service "httpd" do
   action [ :disable, :stop ]
 end
-
-
 
 package 'python-pip'
 package 'libevent-devel'


### PR DESCRIPTION
This PR was started here: https://github.com/ceph/ceph-qa-chef/pull/4

I tested these changes on: rhel 6.5, rhel 7.0, centos 6.4, centos 7, ubuntu 12.04, fedora 18 and fedora 20 by cloning this repo onto the vm, checking out this branch and running sh solo/run.  On centos and ubuntu I had to run solo/solo-from-scratch first with a few lines commented out.  All of them worked fine, except for fedora 18 which complained about not having a ruby version >= 2.0.0.  Which I assume is probably a known issue.

I'm unsure of how to test radosgw.rb, but it looks to only be used for debian-based machines.  Is that true?