### PR TITLE
rm old Fedoras (18 and 19)

### DIFF
--- a/cookbooks/ceph-qa/recipes/fedora.rb
+++ b/cookbooks/ceph-qa/recipes/fedora.rb
@@ -154,18 +154,6 @@ package 'httpd-devel'
 package 'httpd-tools'
 package 'mod_ssl'
 
-if node[:platform_version] == "18"
-  package 'mod_fastcgi' do
-    version '2.4.7-1.ceph.fc18'
-  end
-end
-
-if node[:platform_version] == "19"
-  package 'mod_fastcgi' do
-    version '2.4.7-1.ceph.fc19'
-  end
-end
-
 if node[:platform_version] == "20"
   package 'mod_fastcgi' do
     version '2.4.7-1.ceph.fc20'


### PR DESCRIPTION
Fedora 18 and 19 have reached end of life. This pull request removes them from the configuration.

F19 EOL notification: https://lists.fedoraproject.org/pipermail/announce/2015-January/003248.html

F18 EOL notification: https://lists.fedoraproject.org/pipermail/announce/2014-January/003194.html