### PR TITLE
ntp.conf: use pool of North American NTP servers

### DIFF
--- a/cookbooks/ceph-qa/files/default/ntp.conf
+++ b/cookbooks/ceph-qa/files/default/ntp.conf
@@ -25,7 +25,7 @@ filegen sysstats file sysstats type day enable
 #our internal ones!
 
 # found this guy from http://www.pool.ntp.org/user/ask, ~2.5ms ping time
-server tock.phyber.com iburst minpoll 4 maxpoll 7
+#server tock.phyber.com iburst minpoll 4 maxpoll 7
 
 #server clock1.dreamhost.com iburst dynamic
 #server clock2.dreamhost.com iburst dynamic
@@ -34,6 +34,11 @@ server tock.phyber.com iburst minpoll 4 maxpoll 7
 #server 1.debian.pool.ntp.org iburst dynamic
 #server 2.debian.pool.ntp.org iburst dynamic
 #server 3.debian.pool.ntp.org iburst dynamic
+
+server 0.us.pool.ntp.org
+server 1.us.pool.ntp.org
+server 2.us.pool.ntp.org
+server 3.us.pool.ntp.org
 
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for


### PR DESCRIPTION
Using a single NTP server seems to not be very reliable.  Let's see if the 
full pool does better.

Signed-off-by: Sage Weil <sage@redhat.com>