### PR TITLE
RBD: chef changes to support xfstests on ubuntu 12.04

### DIFF
--- a/cookbooks/ceph-qa/recipes/default.rb
+++ b/cookbooks/ceph-qa/recipes/default.rb
@@ -15,8 +15,17 @@ file '/etc/security/limits.d/ubuntu.conf' do
 end
 
 user "fsgqa" do
+	supports :manage_home => true
+	home "/home/fsgqa"
+	shell "/bin/bash"
 	action :create
 	uid 10101
+end
+
+directory "/home/fsgqa" do
+	owner "fsgqa"
+	mode 00755
+	action :create
 end
 
 if node['hostname'].match(/^(magna)/)

--- a/cookbooks/ceph-qa/recipes/ubuntu.rb
+++ b/cookbooks/ceph-qa/recipes/ubuntu.rb
@@ -308,6 +308,7 @@ package 'quota'
 package 'libcap2-bin'
 package 'libncurses5-dev'
 package 'lvm2'
+package 'gawk'
 
 ruby_block "edit LVM config" do
   block do


### PR DESCRIPTION
Add gawk package, give xfstests's user a home directory to suppress warnings,
explicitly set shell to bash because xfstests uses bashisms.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>